### PR TITLE
fix/core/module-type

### DIFF
--- a/lib/core/package.json
+++ b/lib/core/package.json
@@ -20,8 +20,6 @@
     "@babel/preset-react": "^7.16.5",
     "@babel/preset-typescript": "^7.16.5",
     "@pmmmwh/react-refresh-webpack-plugin": "^0.5.7",
-    "@types/node-fetch": "^2.6.2",
-    "@types/webpack-node-externals": "^2.5.3",
     "babel-loader": "^8.2.3",
     "node-fetch": "^3.2.10",
     "path-to-regexp": "^6.2.0",
@@ -32,6 +30,10 @@
     "webpack-manifest-plugin": "^4.1.1",
     "webpack-node-externals": "^3.0.0",
     "webpack": "^5.74.0"
+  },
+  "devDependencies": {
+    "@types/node-fetch": "^2.6.2",
+    "@types/webpack-node-externals": "^2.5.3"
   },
   "peerDependencies": {
     "react": "18.x",

--- a/lib/core/tsconfig.json
+++ b/lib/core/tsconfig.json
@@ -4,8 +4,8 @@
     "outDir": "./dist",
     "noEmit": false,
     "declaration": true,
-    "target": "ES5",
-    "module": "CommonJS"
+    "target": "ES6",
+    "module": "ES6"
   },
   "include": ["./**/*.ts", "./**/*.tsx", "../../types"],
   "exclude": ["./dist", "./**/*.test.ts", "./**/*.test.tsx"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -106,8 +106,6 @@
         "@babel/preset-react": "^7.16.5",
         "@babel/preset-typescript": "^7.16.5",
         "@pmmmwh/react-refresh-webpack-plugin": "^0.5.7",
-        "@types/node-fetch": "^2.6.2",
-        "@types/webpack-node-externals": "^2.5.3",
         "babel-loader": "^8.2.3",
         "node-fetch": "^3.2.10",
         "path-to-regexp": "^6.2.0",
@@ -118,6 +116,10 @@
         "webpack-dev-server": "^4.9.3",
         "webpack-manifest-plugin": "^4.1.1",
         "webpack-node-externals": "^3.0.0"
+      },
+      "devDependencies": {
+        "@types/node-fetch": "^2.6.2",
+        "@types/webpack-node-externals": "^2.5.3"
       },
       "peerDependencies": {
         "react": "18.x",
@@ -3649,6 +3651,7 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.2.tgz",
       "integrity": "sha512-DHqhlq5jeESLy19TYhLakJ07kNumXWjcDdxXsLUMJZ6ue8VZJj4kLPQVE/2mdHh3xZziNF1xppu5lwmS53HR+A==",
+      "dev": true,
       "dependencies": {
         "@types/node": "*",
         "form-data": "^3.0.0"
@@ -3658,6 +3661,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
       "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+      "dev": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -3793,6 +3797,7 @@
       "version": "2.5.3",
       "resolved": "https://registry.npmjs.org/@types/webpack-node-externals/-/webpack-node-externals-2.5.3.tgz",
       "integrity": "sha512-A9JxaR8QXoYT95egET4AmCFuChyTlP8d18ZAnmSHuIMsFdS7QlCQQ8pmN/+FHgLIkm+ViE/VngltT5avLACY9A==",
+      "dev": true,
       "dependencies": {
         "@types/node": "*",
         "webpack": "^5"
@@ -4630,7 +4635,8 @@
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true
     },
     "node_modules/atomic-sleep": {
       "version": "1.0.0",
@@ -5435,6 +5441,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -5817,6 +5824,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -15936,6 +15944,7 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.2.tgz",
       "integrity": "sha512-DHqhlq5jeESLy19TYhLakJ07kNumXWjcDdxXsLUMJZ6ue8VZJj4kLPQVE/2mdHh3xZziNF1xppu5lwmS53HR+A==",
+      "dev": true,
       "requires": {
         "@types/node": "*",
         "form-data": "^3.0.0"
@@ -15945,6 +15954,7 @@
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
           "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+          "dev": true,
           "requires": {
             "asynckit": "^0.4.0",
             "combined-stream": "^1.0.8",
@@ -16079,6 +16089,7 @@
       "version": "2.5.3",
       "resolved": "https://registry.npmjs.org/@types/webpack-node-externals/-/webpack-node-externals-2.5.3.tgz",
       "integrity": "sha512-A9JxaR8QXoYT95egET4AmCFuChyTlP8d18ZAnmSHuIMsFdS7QlCQQ8pmN/+FHgLIkm+ViE/VngltT5avLACY9A==",
+      "dev": true,
       "requires": {
         "@types/node": "*",
         "webpack": "^5"
@@ -16694,7 +16705,8 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true
     },
     "atomic-sleep": {
       "version": "1.0.0",
@@ -17298,6 +17310,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -17609,7 +17622,8 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true
     },
     "depd": {
       "version": "1.1.2",


### PR DESCRIPTION
It resolves the problem related to the new version of `node-fetch` which forbids `require()`. After compiling the TypeScript code to the `CommonJS` module, the imports become `require()`s and due to that `node-fetch` does not work. 

To avoid that, I've changed the module type to `ES6` and target to `ES6`.