### PR TITLE
fix/core/node-fetch-version

### DIFF
--- a/lib/core/package.json
+++ b/lib/core/package.json
@@ -21,7 +21,7 @@
     "@babel/preset-typescript": "^7.16.5",
     "@pmmmwh/react-refresh-webpack-plugin": "^0.5.7",
     "babel-loader": "^8.2.3",
-    "node-fetch": "^3.2.10",
+    "node-fetch": "2.6.7",
     "path-to-regexp": "^6.2.0",
     "pino-pretty": "^7.3.0",
     "react-refresh": "^0.14.0",

--- a/lib/core/tsconfig.json
+++ b/lib/core/tsconfig.json
@@ -4,8 +4,8 @@
     "outDir": "./dist",
     "noEmit": false,
     "declaration": true,
-    "target": "ES6",
-    "module": "ES6"
+    "target": "ES5",
+    "module": "CommonJS"
   },
   "include": ["./**/*.ts", "./**/*.tsx", "../../types"],
   "exclude": ["./dist", "./**/*.test.ts", "./**/*.test.tsx"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -107,7 +107,7 @@
         "@babel/preset-typescript": "^7.16.5",
         "@pmmmwh/react-refresh-webpack-plugin": "^0.5.7",
         "babel-loader": "^8.2.3",
-        "node-fetch": "^3.2.10",
+        "node-fetch": "2.6.7",
         "path-to-regexp": "^6.2.0",
         "pino-pretty": "^7.3.0",
         "react-refresh": "^0.14.0",
@@ -15469,7 +15469,7 @@
         "@types/node-fetch": "^2.6.2",
         "@types/webpack-node-externals": "^2.5.3",
         "babel-loader": "^8.2.3",
-        "node-fetch": "^3.2.10",
+        "node-fetch": "2.6.7",
         "path-to-regexp": "^6.2.0",
         "pino-pretty": "^7.3.0",
         "react-refresh": "^0.14.0",
@@ -15481,8 +15481,7 @@
       },
       "dependencies": {
         "node-fetch": {
-          "version": "3.2.10",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.2.10.tgz",
+          "version": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.2.10.tgz",
           "integrity": "sha512-MhuzNwdURnZ1Cp4XTazr69K0BTizsBroX7Zx3UgDSVcZYKF/6p0CBe4EUb/hLqmzVhl0UpYfgRljQ4yxE+iCxA==",
           "requires": {
             "data-uri-to-buffer": "^4.0.0",


### PR DESCRIPTION
The fix from https://github.com/ssr-tools/ssr-tools/pull/24 did not work as expected. Although, problem of `node-fetch` did not appear, other module type conflicts occurred. For now, I downgrade the `node-fetch` to `2.x.x` to avoid difficulties related to forbidden `CommonJS` in `node-fetch@3.x.x`.