### PR TITLE
fix/with-fastify/protocol

### DIFF
--- a/examples/with-fastify/server.tsx
+++ b/examples/with-fastify/server.tsx
@@ -23,7 +23,10 @@ fastify.register(fastifyStatic, {
 });
 
 fastify.get("*", async (request, reply) => {
-  const appUrl = new URL(request.url, `http://${request.headers.host}`);
+  const appUrl = new URL(
+    request.url,
+    `${request.protocol}://${request.headers.host}`
+  );
 
   const assetsUrl =
     process.env.NODE_ENV === "production"


### PR DESCRIPTION
It replaces hard-coded `http` protocol with the original protocol provided in `request.protocol`. This way, we can avoid mixing up `http` and `https` protocols (https://developer.mozilla.org/en-US/docs/Web/Security/Mixed_content).